### PR TITLE
Supporto fan coil CAME nell'integrazione climate

### DIFF
--- a/custom_components/came/climate.py
+++ b/custom_components/came/climate.py
@@ -1,25 +1,34 @@
 """Support for the CAME climate devices."""
 
+import logging
 from typing import Optional
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.climate import (
     ENTITY_ID_FORMAT,
-    HVACMode,  # Nuovo: sostituisce le vecchie costanti HVAC_MODE_*
+    HVACMode,
     ClimateEntity,
-    ClimateEntityFeature,  # Per sostituire SUPPORT_* vecchie costanti
+    ClimateEntityFeature,
 )
-from homeassistant.components.climate.const import (
-    HVACMode,  # Nuovo: sostituisce HVAC_MODE_*
+from homeassistant.components.climate.const import HVACAction
+from pycame.devices.came_thermo import (
+    THERMO_FAN_SPEED_SLOW,
+    THERMO_FAN_SPEED_MEDIUM,
+    THERMO_FAN_SPEED_FAST,
+    THERMO_FAN_SPEED_AUTO,
+    THERMO_MODE_OFF,
 )
+
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     PRECISION_TENTHS,
-    UnitOfTemperature,  # Sostituisce TEMP_CELSIUS
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
 from pycame.came_manager import CameManager
 from pycame.devices import CameDevice
 from pycame.devices.came_thermo import (
@@ -36,31 +45,27 @@ from pycame.devices.came_thermo import (
 from .const import CONF_MANAGER, CONF_PENDING, DOMAIN, SIGNAL_DISCOVERY_NEW
 from .entity import CameEntity
 
-# Vecchie costanti HVAC_MODE sostituite con le nuove HVACMode.*
+_LOGGER = logging.getLogger(__name__)
+
 CAME_MODE_TO_HA = {
-    THERMO_MODE_OFF: HVACMode.OFF,  # HVAC_MODE_OFF deprecato
-    THERMO_MODE_AUTO: HVACMode.AUTO,  # HVAC_MODE_AUTO deprecato
-    THERMO_MODE_JOLLY: HVACMode.AUTO,  # HVAC_MODE_AUTO deprecato
+    THERMO_MODE_OFF: HVACMode.OFF,
+    THERMO_MODE_AUTO: HVACMode.AUTO,
+    THERMO_MODE_JOLLY: HVACMode.AUTO,
 }
 
-# Vecchie costanti HVAC_MODE sostituite con le nuove HVACMode.*
 CAME_SEASON_TO_HA = {
-    THERMO_SEASON_OFF: HVACMode.OFF,  # HVAC_MODE_OFF deprecato
-    THERMO_SEASON_WINTER: HVACMode.HEAT,  # HVAC_MODE_HEAT deprecato
-    THERMO_SEASON_SUMMER: HVACMode.COOL,  # HVAC_MODE_COOL deprecato
+    THERMO_SEASON_OFF: HVACMode.OFF,
+    THERMO_SEASON_WINTER: HVACMode.HEAT,
+    THERMO_SEASON_SUMMER: HVACMode.COOL,
 }
 
 
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
 ):
-    """Set up CAME sensors dynamically through discovery."""
-
     async def async_discover_sensor(dev_ids):
-        """Discover and add a discovered CAME sensor."""
         if not dev_ids:
             return
-
         entities = await hass.async_add_executor_job(_setup_entities, hass, dev_ids)
         async_add_entities(entities)
 
@@ -73,96 +78,169 @@ async def async_setup_entry(
 
 
 def _setup_entities(hass, dev_ids):
-    """Set up CAME Climate device."""
     manager = hass.data[DOMAIN][CONF_MANAGER]  # type: CameManager
     entities = []
     for dev_id in dev_ids:
         device = manager.get_device_by_id(dev_id)
         if device is None:
             continue
-        entities.append(CameClimateEntity(device))
+
+        if getattr(device, "support_fan_speed", False):
+            _LOGGER.info(
+                "💨 Fan coil rilevato: %s → entità CameFancoilClimateEntity",
+                device.name,
+            )
+            entities.append(CameFancoilClimateEntity(device))
+        else:
+            _LOGGER.info(
+                "🌡️ Termostato rilevato: %s → entità CameClimateEntity", device.name
+            )
+            entities.append(CameClimateEntity(device))
     return entities
 
 
 class CameClimateEntity(CameEntity, ClimateEntity):
-    """CAME climate device entity."""
-
     def __init__(self, device: CameDevice):
-        """Init CAME climate device entity."""
         super().__init__(device)
-
         self.entity_id = ENTITY_ID_FORMAT.format(self.unique_id)
 
-        # Modificato: Sostituite le vecchie costanti SUPPORT_* con ClimateEntityFeature.*
         self._attr_supported_features = (
-            (ClimateEntityFeature.TARGET_TEMPERATURE if self._device.support_target_temperature else 0) |
-            (ClimateEntityFeature.TARGET_HUMIDITY if self._device.support_target_humidity else 0) |
-            (ClimateEntityFeature.FAN_MODE if self._device.support_fan_speed else 0) |
-            ClimateEntityFeature.TURN_ON |
-            ClimateEntityFeature.TURN_OFF  # Aggiunta per turn_on/turn_off
+            (
+                ClimateEntityFeature.TARGET_TEMPERATURE
+                if device.support_target_temperature
+                else 0
+            )
+            | (
+                ClimateEntityFeature.TARGET_HUMIDITY
+                if device.support_target_humidity
+                else 0
+            )
+            | ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
         )
 
-        # Modificato: Sostituito PRECISION_TENTHS con il nuovo attributo
         self._attr_target_temperature_step = PRECISION_TENTHS
-        # Modificato: Sostituito TEMP_CELSIUS con UnitOfTemperature.CELSIUS
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
 
     @property
     def current_temperature(self) -> Optional[float]:
-        """Return the current temperature."""
         return self._device.current_temperature
 
     @property
     def target_temperature(self) -> Optional[float]:
-        """Return the temperature we try to reach."""
         return self._device.target_temperature
 
     @property
     def target_humidity(self) -> Optional[int]:
-        """Return the humidity we try to reach."""
         return self._device.target_humidity
 
     @property
     def hvac_mode(self):
-        """Return current operation ie. heat, cool, idle."""
-        if not self._device.state:
-            return HVACMode.OFF  # Modificato: Sostituito HVAC_MODE_OFF con HVACMode.OFF
+        """Return current HVAC mode set by user (not current action)."""
 
         if self._device.mode in CAME_MODE_TO_HA:
             return CAME_MODE_TO_HA[self._device.mode]
-
         if self._device.dehumidifier_state == THERMO_DEHUMIDIFIER_ON:
-            return HVACMode.DRY  # Modificato: Sostituito HVAC_MODE_DRY con HVACMode.DRY
+            return HVACMode.DRY
+        return CAME_SEASON_TO_HA.get(self._device.season, HVACMode.OFF)
 
-        return CAME_SEASON_TO_HA[self._device.season]
+    @property
+    def hvac_action(self) -> Optional[HVACAction]:
+        """Return the current running hvac operation for thermostats."""
+        _LOGGER.debug(
+            "🛠️ HVAC Action - Stato attuale: state=%s, active=%s, season=%s",
+            self._device.state,
+            getattr(self._device, "active", "N/A"),
+            self._device.season,
+        )
+
+        if self._device.mode == THERMO_MODE_OFF:
+            return HVACAction.OFF
+
+        if self._device.state == 1:
+            if self._device.season == THERMO_SEASON_WINTER:
+                return HVACAction.HEATING
+            elif self._device.season == THERMO_SEASON_SUMMER:
+                return HVACAction.COOLING
+            return HVACAction.HEATING  # fallback in caso di stagione non definita
+
+        return HVACAction.IDLE
 
     @property
     def hvac_modes(self):
-        """Return the list of available operation modes."""
-        operations = [
-            HVACMode.OFF,  # Sostituisce HVAC_MODE_OFF
-            HVACMode.AUTO,  # Sostituisce HVAC_MODE_AUTO
-            HVACMode.HEAT,  # Sostituisce HVAC_MODE_HEAT
-            HVACMode.COOL,  # Sostituisce HVAC_MODE_COOL
-        ]
+        ops = [HVACMode.OFF, HVACMode.AUTO, HVACMode.HEAT, HVACMode.COOL]
         if self._device.support_target_humidity:
-            operations.append(HVACMode.DRY)  # Modificato: Sostituito HVAC_MODE_DRY con HVACMode.DRY
-        return operations
+            ops.append(HVACMode.DRY)
+        return ops
 
     def set_temperature(self, **kwargs) -> None:
-        """Set new target temperature."""
         if ATTR_TEMPERATURE in kwargs:
             self._device.set_target_temperature(kwargs[ATTR_TEMPERATURE])
 
     def set_hvac_mode(self, hvac_mode: str) -> None:
-        """Set new target hvac mode."""
-        if hvac_mode == HVACMode.OFF:  # Sostituisce HVAC_MODE_OFF
+        if hvac_mode == HVACMode.OFF:
             self._device.zone_config(mode=THERMO_MODE_OFF)
-        elif hvac_mode == HVACMode.HEAT:  # Sostituisce HVAC_MODE_HEAT
-            self._device.zone_config(mode=THERMO_MODE_MANUAL, season=THERMO_SEASON_WINTER)
-        elif hvac_mode == HVACMode.COOL:  # Sostituisce HVAC_MODE_COOL
-            self._device.zone_config(mode=THERMO_MODE_MANUAL, season=THERMO_SEASON_SUMMER)
-        # pylint: disable=fixme
-        # todo: Set up dehumidifier when hvac_mode == HVACMode.DRY
+        elif hvac_mode == HVACMode.HEAT:
+            self._device.zone_config(
+                mode=THERMO_MODE_MANUAL, season=THERMO_SEASON_WINTER
+            )
+        elif hvac_mode == HVACMode.COOL:
+            self._device.zone_config(
+                mode=THERMO_MODE_MANUAL, season=THERMO_SEASON_SUMMER
+            )
+        elif hvac_mode == HVACMode.AUTO:
+            self._device.zone_config(mode=THERMO_MODE_AUTO)
         else:
-            self._device.zone_config(mode=THERMO_MODE_AUTO)  # Modificato: Sostituito HVAC_MODE_AUTO con HVACMode.AUTO
+            self._device.zone_config(mode=THERMO_MODE_AUTO)
+
+
+class CameFancoilClimateEntity(CameClimateEntity):
+    def __init__(self, device: CameDevice):
+        super().__init__(device)
+        self._attr_supported_features |= ClimateEntityFeature.FAN_MODE
+        self._attr_fan_modes = ["auto", "low", "medium", "high"]
+        _LOGGER.info(
+            "🎛️ Fan coil %s: modalità disponibili %s", device.name, self._attr_fan_modes
+        )
+
+    @property
+    def hvac_action(self) -> Optional[HVACAction]:
+        """Return the current running HVAC action for fan coil."""
+        if self._device.mode == THERMO_MODE_OFF:
+            return HVACAction.OFF
+        if self._device.fan_speed in [
+            THERMO_FAN_SPEED_SLOW,
+            THERMO_FAN_SPEED_MEDIUM,
+            THERMO_FAN_SPEED_FAST,
+            THERMO_FAN_SPEED_AUTO,
+        ]:
+            return HVACAction.FAN
+        return HVACAction.IDLE
+
+    @property
+    def fan_mode(self) -> Optional[str]:
+        # Legge la velocità attuale dal dispositivo
+        fan_mode = getattr(self._device, "fan_mode", None)
+        if fan_mode is not None:
+            # Normalizza in minuscolo per Home Assistant
+            return fan_mode.lower()
+        return None
+
+    def set_fan_mode(self, fan_mode: str) -> None:
+        _LOGGER.info("🔁 Cambio velocità ventilatore: richiesta %s", fan_mode)
+        if fan_mode in self._attr_fan_modes:
+            if hasattr(self._device, "set_fan_speed"):
+                # Invia al dispositivo il fan_mode in MAIUSCOLO (perché CAME usa MAIUSCOLO)
+                self._device.set_fan_speed(fan_mode.upper())
+            else:
+                _LOGGER.warning(
+                    "⛔ Il dispositivo %s NON supporta set_fan_speed", self._device.name
+                )
+        else:
+            _LOGGER.warning("🚫 Modalità ventilatore non valida: %s", fan_mode)
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set fan mode asynchronously."""
+        _LOGGER.info("🔁 [ASYNC] Cambio velocità ventilatore: richiesta %s", fan_mode)
+        await self.hass.async_add_executor_job(self.set_fan_mode, fan_mode)
+        self.async_write_ha_state()


### PR DESCRIPTION
In questa PR ho aggiunto il supporto ai fan coil (sia 2 che 4 tubi) nell'integrazione climate di ha_came. I principali cambiamenti includono:

- Rilevamento automatico del tipo di dispositivo (termostato o fan coil)
- Aggiunta di logica dedicata per i fan coil
- Corretto il comportamento della modalità OFF
- Rifattorizzazione per migliorare la leggibilità e mantenere la retrocompatibilità

Testato su 25 dispositivi reali in ambiente Home Assistant (termistati e fan coil). Compatibile con la nuova versione della libreria python_came_manager.